### PR TITLE
If a prefix is being used, add a leading slash.

### DIFF
--- a/src/JsonApiClient.php
+++ b/src/JsonApiClient.php
@@ -180,9 +180,12 @@ class JsonApiClient
         $prefix = null;
         if (array_key_exists('path', $url)) {
             $prefix = trim($url['path'], '/');
+            if (!empty($prefix)) {
+                $prefix .= '/';
+            }
         }
 
-        $requestUri = $requestUri->withPath($prefix . '/' . trim($requestUri->getPath(), '/'));
+        $requestUri = $requestUri->withPath('/' . $prefix . trim($requestUri->getPath(), '/'));
 
         return new Request($method, $requestUri, $body, $prefix);
     }


### PR DESCRIPTION
The following error is thrown by Guzzle, when urls are being prefixed.

> User Deprecated: The path of a URI with an authority must start with a slash "/" or be empty. Automagically fixing the URI by adding a leading slash to the path is deprecated since version 1.4 and will throw an exception instead.