### PR TITLE
Bugfix: withBody() returns a new instance that has the new body stream.

### DIFF
--- a/src/JsonApiClient.php
+++ b/src/JsonApiClient.php
@@ -138,7 +138,7 @@ class JsonApiClient
     {
         $httpRequest = $this->requestFactory->createRequest($request->method(), $request->uri());
         if ($request->requestBody()) {
-            $httpRequest->withBody(
+            $httpRequest = $httpRequest->withBody(
                 $this->streamFactory->createStream(
                     json_encode($this->serializer->serializeDocument($request->requestBody()))
                 )


### PR DESCRIPTION
According to the PSR interface must the function withBody()return a new instance that has the new body stream.
So it is important to assign the return value to the $httpRequest variable so we don't end up with an empty body.

See https://github.com/php-fig/http-message/blob/master/src/MessageInterface.php#L186

> This method MUST be implemented in such a way as to retain the
> immutability of the message, and MUST return a new instance that has the
> new body stream.